### PR TITLE
Fix Scoping Issue for Grid Selected 

### DIFF
--- a/conf/com.example.demo.controllers.LoginController.properties
+++ b/conf/com.example.demo.controllers.LoginController.properties
@@ -1,4 +1,4 @@
 #
-#Tue Apr 03 02:31:27 EDT 2018
+#Wed Apr 04 18:01:06 EDT 2018
 password=secret
 username=admin

--- a/src/main/kotlin/com/example/demo/controllers/WorkbenchController.kt
+++ b/src/main/kotlin/com/example/demo/controllers/WorkbenchController.kt
@@ -1,5 +1,7 @@
 package com.example.demo.controllers
 
+import com.example.demo.model.GridInfoModel
+import com.example.demo.model.HomepageGridBuilder
 import com.example.demo.views.*
 import tornadofx.*
 
@@ -7,7 +9,9 @@ class WorkbenchController : Controller() {
 
     /***** Global Variables *****/
     private val workbench: Workbench by inject()
-    var tile = 0
+    private val gridInfo: GridInfoModel by inject()
+
+    private val grids = resources.jsonArray("/JSON/GridInfo.json").toModel<HomepageGridBuilder>()
 
     /**
      * Decide which grid to use and switch views from workbench to demo gui
@@ -15,8 +19,11 @@ class WorkbenchController : Controller() {
      * @property String image
      */
     fun goToEditor(image: String) {
-        tile = parseImage(image)
-        workbench.replaceWith(find<TileGUI>(), centerOnScreen = true, sizeToScene = true)
+        gridInfo.useTileGrid(grids, parseImage(image))
+        val scope = Scope()
+        scope.set(gridInfo)
+        DefaultScope.set(gridInfo)
+        workbench.replaceWith(find<TileGUI>(scope), centerOnScreen = true, sizeToScene = true)
     }
 
     /**

--- a/src/main/kotlin/com/example/demo/controllers/WorkbenchController.kt
+++ b/src/main/kotlin/com/example/demo/controllers/WorkbenchController.kt
@@ -22,7 +22,6 @@ class WorkbenchController : Controller() {
         gridInfo.useTileGrid(grids, parseImage(image))
         val scope = Scope()
         scope.set(gridInfo)
-        DefaultScope.set(gridInfo)
         workbench.replaceWith(find<TileGUI>(scope), centerOnScreen = true, sizeToScene = true)
     }
 

--- a/src/main/kotlin/com/example/demo/model/DragTile.kt
+++ b/src/main/kotlin/com/example/demo/model/DragTile.kt
@@ -1,0 +1,54 @@
+package com.example.demo.model
+
+import eu.hansolo.tilesfx.Tile
+import javafx.beans.property.Property
+import tornadofx.Commit
+import tornadofx.ItemViewModel
+import tornadofx.getProperty
+import tornadofx.property
+
+/***** Data classes and models intended for tile and grid location, saving
+ *     tile objects needed for module rendering,
+ *     dragging, and copying in a view  *****/
+
+class DragTile(tile: Tile, colSpan: Int, rowSpan: Int, colIndex: Int,
+               rowIndex: Int) {
+    var tile by property(tile)
+    fun tileProperty() = getProperty(DragTile::tile)
+
+    var colSpan by property(colSpan)
+    fun colSpanProperty() = getProperty(DragTile::colSpan)
+
+    var rowSpan by property(rowSpan)
+    fun rowSpanProperty() = getProperty(DragTile::rowSpan)
+
+    var colIndex by property(colIndex)
+    fun colIndexProperty() = getProperty(DragTile::colIndex)
+
+    var rowIndex by property(rowIndex)
+    fun rowIndexProperty() = getProperty(DragTile::rowIndex)
+}
+
+class DragTileModel : ItemViewModel<DragTile>() {
+    private val tile = bind { item?.tileProperty()  }
+    private val colSpan = bind { item?.colSpanProperty() }
+    private val rowSpan = bind { item?.rowSpanProperty() }
+    private val colIndex = bind { item?.colIndexProperty() }
+    private val rowIndex = bind { item?.rowIndexProperty() }
+
+    override fun onCommit(commits: List<Commit>) {
+        super.onCommit(commits)
+
+        // The println will only be called if findChanged is not null
+        commits.findChanged(tile)?.let { println("Module Tile changed from ${it.first} to ${it.second}")}
+        commits.findChanged(colSpan)?.let { println("Column Span changed from ${it.first} to ${it.second}")}
+        commits.findChanged(rowSpan)?.let { println("Row Span changed from ${it.first} to ${it.second}")}
+        commits.findChanged(colIndex)?.let { println("Column Index changed from ${it.first} to ${it.second}")}
+        commits.findChanged(rowIndex)?.let { println("Row Index changed from ${it.first} to ${it.second}")}
+    }
+
+    private fun <T> List<Commit>.findChanged(ref: Property<T>): Pair<T, T>? {
+        val commit = find { it.property == ref && it.changed}
+        return commit?.let { (it.newValue as T) to (it.oldValue as T) }
+    }
+}

--- a/src/main/kotlin/com/example/demo/model/GridInfo.kt
+++ b/src/main/kotlin/com/example/demo/model/GridInfo.kt
@@ -1,10 +1,9 @@
 package com.example.demo.model
 
+import eu.hansolo.tilesfx.Tile
+import eu.hansolo.tilesfx.TileBuilder
 import javafx.beans.property.Property
-import tornadofx.Commit
-import tornadofx.ItemViewModel
-import tornadofx.getProperty
-import tornadofx.property
+import tornadofx.*
 
 /***** Data classes and models intended for grid rendering *****/
 
@@ -32,4 +31,32 @@ class GridInfoModel : ItemViewModel<GridInfo>() {
         val commit = find { it.property == ref && it.changed}
         return commit?.let { (it.newValue as T) to (it.oldValue as T) }
     }
+
+    fun useTileGrid(grids: List<HomepageGridBuilder>, grid: Int) {
+        grids.asSequence().forEach {
+            if (grid == it.grid) {
+                val gridTiles = it.tiles.map(::createTilePlacement)
+                item = GridInfo(Pair(Pair(it.rows, it.columns), gridTiles))
+            }
+        }
+    }
+
+    private fun createTilePlacement(hpb: HomepageTileBuilder): TilePlacement {
+        return TilePlacement(gridTileBuilder(hpb.title, hpb.width, hpb.height),
+                hpb.colIndex, hpb.rowIndex, hpb.colSpan, hpb.rowSpan)
+    }
+
+    /**
+     * Grid Tile Builder, simplified tile
+     *
+     * @property String title
+     * @property Double width
+     */
+    private fun gridTileBuilder(title: String, width: Double = 100.0, height: Double = 100.0) : Tile
+            = TileBuilder.create()
+            .skinType(Tile.SkinType.TEXT)
+            .title(title)
+            .maxSize(width, height)
+            .roundedCorners(false)
+            .build()
 }

--- a/src/main/kotlin/com/example/demo/model/GridInfo.kt
+++ b/src/main/kotlin/com/example/demo/model/GridInfo.kt
@@ -1,0 +1,35 @@
+package com.example.demo.model
+
+import javafx.beans.property.Property
+import tornadofx.Commit
+import tornadofx.ItemViewModel
+import tornadofx.getProperty
+import tornadofx.property
+
+/***** Data classes and models intended for grid rendering *****/
+
+class GridInfo(info: Pair<Pair<Int, Int>, List<TilePlacement>>) {
+
+    private var coordinates by property(info.first)
+    fun coordinatesProperty() = getProperty(GridInfo::coordinates)
+
+    var rows: Int by property(info.first.first)
+    var columns: Int by property(info.first.second)
+    var moduleTiles by property(info.second)
+}
+
+class GridInfoModel : ItemViewModel<GridInfo>() {
+    private val coordinates = bind { item?.coordinatesProperty() }
+
+    override fun onCommit(commits: List<Commit>) {
+        super.onCommit(commits)
+
+        // The println will only be called if findChanged is not null
+        commits.findChanged(coordinates)?.let { println("Grid Info changed from ${it.first} to ${it.second}")}
+    }
+
+    private fun <T> List<Commit>.findChanged(ref: Property<T>): Pair<T, T>? {
+        val commit = find { it.property == ref && it.changed}
+        return commit?.let { (it.newValue as T) to (it.oldValue as T) }
+    }
+}

--- a/src/main/kotlin/com/example/demo/model/TilePlacement.kt
+++ b/src/main/kotlin/com/example/demo/model/TilePlacement.kt
@@ -4,33 +4,6 @@ import eu.hansolo.tilesfx.Tile
 import javafx.beans.property.Property
 import tornadofx.*
 
-/***** Data classes and models intended for grid rendering *****/
-
-class GridInfo(info: Pair<Pair<Int, Int>, List<TilePlacement>>) {
-
-    private var coordinates by property(info.first)
-    fun coordinatesProperty() = getProperty(GridInfo::coordinates)
-
-    var rows: Int by property(info.first.first)
-    var columns: Int by property(info.first.second)
-    var moduleTiles by property(info.second)
-}
-
-class GridInfoModel : ItemViewModel<GridInfo>() {
-    private val coordinates = bind { item?.coordinatesProperty() }
-
-    override fun onCommit(commits: List<Commit>) {
-        super.onCommit(commits)
-
-        // The println will only be called if findChanged is not null
-        commits.findChanged(coordinates)?.let { println("Grid Info changed from ${it.first} to ${it.second}")}
-    }
-
-    private fun <T> List<Commit>.findChanged(ref: Property<T>): Pair<T, T>? {
-        val commit = find { it.property == ref && it.changed}
-        return commit?.let { (it.newValue as T) to (it.oldValue as T) }
-    }
-}
 
 /***** Data classes and models intended for tile and grid location and properties
  *     NOTE: revisit models for refactoring *****/
@@ -79,48 +52,3 @@ class GridScope: Scope() {
     val model = GridInfoModel()
 }
 
-/***** Data classes and models intended for tile and grid location, saving
- *     tile objects needed for module rendering,
- *     dragging, and copying in a view  *****/
-
-class DragTile(tile: Tile, colSpan: Int, rowSpan: Int, colIndex: Int,
-               rowIndex: Int) {
-    var tile by property(tile)
-    fun tileProperty() = getProperty(DragTile::tile)
-
-    var colSpan by property(colSpan)
-    fun colSpanProperty() = getProperty(DragTile::colSpan)
-
-    var rowSpan by property(rowSpan)
-    fun rowSpanProperty() = getProperty(DragTile::rowSpan)
-
-    var colIndex by property(colIndex)
-    fun colIndexProperty() = getProperty(DragTile::colIndex)
-
-    var rowIndex by property(rowIndex)
-    fun rowIndexProperty() = getProperty(DragTile::rowIndex)
-}
-
-class DragTileModel : ItemViewModel<DragTile>() {
-    private val tile = bind { item?.tileProperty()  }
-    private val colSpan = bind { item?.colSpanProperty() }
-    private val rowSpan = bind { item?.rowSpanProperty() }
-    private val colIndex = bind { item?.colIndexProperty() }
-    private val rowIndex = bind { item?.rowIndexProperty() }
-
-    override fun onCommit(commits: List<Commit>) {
-        super.onCommit(commits)
-
-        // The println will only be called if findChanged is not null
-        commits.findChanged(tile)?.let { println("Module Tile changed from ${it.first} to ${it.second}")}
-        commits.findChanged(colSpan)?.let { println("Column Span changed from ${it.first} to ${it.second}")}
-        commits.findChanged(rowSpan)?.let { println("Row Span changed from ${it.first} to ${it.second}")}
-        commits.findChanged(colIndex)?.let { println("Column Index changed from ${it.first} to ${it.second}")}
-        commits.findChanged(rowIndex)?.let { println("Row Index changed from ${it.first} to ${it.second}")}
-    }
-
-    private fun <T> List<Commit>.findChanged(ref: Property<T>): Pair<T, T>? {
-        val commit = find { it.property == ref && it.changed}
-        return commit?.let { (it.newValue as T) to (it.oldValue as T) }
-    }
-}

--- a/src/main/kotlin/com/example/demo/views/MyTiles.kt
+++ b/src/main/kotlin/com/example/demo/views/MyTiles.kt
@@ -1,5 +1,6 @@
 package com.example.demo.views
 
+import com.example.demo.model.GridInfoModel
 import com.example.demo.model.GridScope
 import javafx.geometry.HPos
 import javafx.geometry.Pos
@@ -12,9 +13,7 @@ import tornadofx.gridpane
 
 class MyTiles : View() {
     /***** Global Variables *****/
-    override val scope = super.scope as GridScope
-    private val model = scope.model
-    private val gridInfo = model.item
+    private val model: GridInfoModel by inject()
 
     /***** View *****/
     override val root = gridpane {
@@ -26,7 +25,7 @@ class MyTiles : View() {
         columnConstraints.clear()
         rowConstraints.clear()
 
-        for (i in 0 until gridInfo.columns) {
+        for (i in 0 until model.item.columns) {
             val c = ColumnConstraints().apply {
                 halignment = HPos.CENTER
                 hgrow = Priority.NEVER
@@ -36,7 +35,7 @@ class MyTiles : View() {
             columnConstraints.add(c)
         }
 
-        for (i in 0 until gridInfo.rows) {
+        for (i in 0 until model.item.rows) {
             val r = RowConstraints().apply {
                 valignment = VPos.CENTER
                 vgrow = Priority.NEVER
@@ -48,7 +47,7 @@ class MyTiles : View() {
     }
 
     init {
-        gridInfo.moduleTiles.forEach {
+        model.item.moduleTiles.forEach {
             root.add(it.tile, it.colIndex, it.rowIndex, it.colSpan, it.rowSpan)
         }
     }

--- a/src/main/kotlin/com/example/demo/views/TileGUI.kt
+++ b/src/main/kotlin/com/example/demo/views/TileGUI.kt
@@ -7,6 +7,7 @@ import com.example.demo.controllers.TileBuilderController
 import com.example.demo.controllers.TileGUIController
 import com.example.demo.controllers.WorkbenchController
 import com.example.demo.model.GridInfo
+import com.example.demo.model.GridInfoModel
 import com.example.demo.model.GridScope
 import javafx.application.Platform
 import javafx.geometry.Pos
@@ -22,19 +23,13 @@ class TileGUI : View() {
     /***** Global Variables *****/
     private val loginController: LoginController by inject()
     private val tileBuilderController: TileBuilderController by inject()
-    val workbenchController: WorkbenchController by inject()
     private val controller: TileGUIController by inject()
-
-    lateinit var gridInfo: GridInfo
 
     // drag variables
     var moduleBoxItems = mutableListOf<Node>()
-    var workArea: GridPane by singleAssign()
 
     /***** View *****/
     override val root = stackpane {
-        gridInfo = GridInfo(controller.useTileGrid(workbenchController.tile))
-        workArea = passGridInfo(gridInfo)
         setPrefSize(1000.0, 650.0)
 
         borderpane {
@@ -45,17 +40,13 @@ class TileGUI : View() {
                 }
                 menubar {
                     menu("File") {
-                        item("Logout").action {
-                            loginController.logout()
-                        }
-                        item("Quit").action {
-                            Platform.exit()
-                        }
+                        item("Logout").action(loginController::logout)
+                        item("Quit").action(Platform::exit)
                     }
                 }
             }
 
-            center = workArea.addClass(Styles.grid)
+            center(MyTiles::class)
 
             right {
                 vbox {
@@ -72,9 +63,7 @@ class TileGUI : View() {
                                 minWidth = 300.0
 
                                 cellFormat {
-                                    graphic = it.apply {
-                                        addClass(Styles.highlightTile)
-                                    }
+                                    graphic = it.apply { addClass(Styles.highlightTile) }
                                 }
                             }
                         }
@@ -89,19 +78,14 @@ class TileGUI : View() {
 
                                 cellFormat {
                                     graphic = it
-                                    style {
-                                        backgroundColor += c("#222222")
-                                    }
+                                    style { backgroundColor += c("#222222") }
                                 }
                             }
                         }
                     }
 
                     hbox {
-                        hboxConstraints {
-                            alignment = Pos.BASELINE_RIGHT
-                        }
-
+                        hboxConstraints { alignment = Pos.BASELINE_RIGHT }
                         button("Return to Workbench") {
                             hboxConstraints {
                                 marginLeftRight(10.0)
@@ -147,15 +131,4 @@ class TileGUI : View() {
     init {
         moduleBoxItems.addAll( tileBuilderController.tileList )
     }
-}
-
-/**
- * Render workarea by passing chosen grid information.
- *
- * @property GridInfo gridInfo
- */
-private fun passGridInfo(gridInfo: GridInfo): GridPane {
-    val gridScope = GridScope()
-    gridScope.model.item = gridInfo
-    return find<MyTiles>(gridScope).root
 }

--- a/src/main/kotlin/com/example/demo/views/Workbench.kt
+++ b/src/main/kotlin/com/example/demo/views/Workbench.kt
@@ -62,9 +62,7 @@ class Workbench : View() {
                         }
                     }
                 }
-                onUserSelect(2) {
-                    workbenchController.goToEditor(it)
-                }
+                onUserSelect(2) { workbenchController.goToEditor(it) }
             }
         }
 


### PR DESCRIPTION
# Changes
- Moved models and view models to separate files
- Moved functionality for selecting `GridInfo` from `WorkbenchController` to `GridInfoModel`.
- Create new `Scope` with `GridInfoModel` and inject into `TileGUI`.
- Deleted the creation of `GridScope` in `TileGUI` b/c it is the wrong place to create it. 
- Removed some unnecessary references.

## Future Notes
You can still use `GridScope` however in this version I instantiate a `Scope` with a `GridInfoModel` in `WorkbenchController` and inject it into `TileGUI`. There does not seem to be a need to use `GridScope` in the app's current state. 